### PR TITLE
Snipcart Localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,6 @@ public
 temp
 temp-*
 
-gatsby-ssr.js
+# gatsby-ssr.js
 gatsby-browser.js
 !src/*.js

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -31,7 +31,7 @@ exports.onRenderBody = ({ setPostBodyComponents }, options = {}) => {
 		components.push(<link key='snipcartStyle' href={options.styles} type="text/css" rel="stylesheet" />)
 	}
 	if {options.language}{
-		components.unshift(<script key='snipcartLanguage' src={options.language}></script>)
+		components.push(<script key='snipcartLanguage' src={options.language}></script>)
 	}
 
 	return setPostBodyComponents(components)

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,6 +1,7 @@
 import React from 'react'
 
 let warning = false
+let linkToLangFile = null
 
 exports.onRenderBody = ({ setPostBodyComponents }, options = {}) => {
 	options = Object.assign({
@@ -9,6 +10,7 @@ exports.onRenderBody = ({ setPostBodyComponents }, options = {}) => {
 		js: 'https://cdn.snipcart.com/scripts/2.0/snipcart.js',
 		jquery: 'https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js',
 		styles: 'https://cdn.snipcart.com/themes/2.0/base/snipcart.min.css',
+		language: `${linkToLangFile}`,
 	}, options)
 
 	if(!options.apiKey){
@@ -27,6 +29,9 @@ exports.onRenderBody = ({ setPostBodyComponents }, options = {}) => {
 	}
 	if (options.styles){
 		components.push(<link key='snipcartStyle' href={options.styles} type="text/css" rel="stylesheet" />)
+	}
+	if {options.language}{
+		components.unshift(<script key='snipcartLanguage' src={options.language}></script>)
 	}
 
 	return setPostBodyComponents(components)


### PR DESCRIPTION
In your gatsby-config.js file, add:

module.exports = {
	plugins: [
		{
			resolve: 'gatsby-plugin-snipcart',
			options: {
				language: 'FULL_LINK_TO_LANG_FILE'
			}
		}
	]
}

"https://github.com/snipcart/snipcart-localization" for all the supported languages


The next step is to specify which language you are currently using. Snipcart relies on the lang attribute in the html tag.

<!DOCTYPE html>
<html lang="en">
...
</html>